### PR TITLE
Get working with Mercurial plugin (and Subversion too).

### DIFF
--- a/lib/ci_skip/matcher.rb
+++ b/lib/ci_skip/matcher.rb
@@ -5,7 +5,7 @@ module CiSkip
     end
 
     def skip?
-      !!(@message =~ /\[ci\s+skip\]|\[skip\s+ci\]/i)
+      !!(@message =~ /\[ci\s+skip\\?\]|\[skip\s+ci\\?\]/i)
     end
   end
 end

--- a/models/ci_skip_wrapper.rb
+++ b/models/ci_skip_wrapper.rb
@@ -19,11 +19,21 @@ class CiSkipWrapper < Jenkins::Tasks::BuildWrapper
 
       logs = changeset.getLogs()
       latest_commit = logs.get(logs.size - 1)
-      comment = latest_commit.getComment()
+      if latest_commit.respond_to?(:getComment)
+        comment = latest_commit.getComment()
+      elsif latest_commit.respond_to?(:getMsg)
+        comment = latest_commit.getMsg()
+      end
 
       if CiSkip::Matcher.new(comment).skip?
         listener.info "Build is skipped through commit message."
-        listener.info "Commit: #{latest_commit.getCommitId()}"
+        if latest_commit.respond_to?(:getCommitId)
+          listener.info "Commit: #{latest_commit.getCommitId()}"
+        elsif latest_commit.respond_to?(:getNode)
+          listener.info "Commit: #{latest_commit.getNode()}"
+        else
+          listener.info "Commit: version/id unknown"
+        end
         listener.info "Message: #{comment}"
         halt(build)
       end


### PR DESCRIPTION
Added duck typing re different methods provided by git and mercurial plugins, so that the CI Skip plugin can skip commits coming from Mercurial, dependant on content in the commit message.

The git plugin provides the commit message via getComment, and getCommitId for the id of that commit.
The Mercurial plugin provides the same information via getMsg and getNode respectively.

Compare https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitChangeSet.java and https://github.com/jenkinsci/mercurial-plugin/blob/master/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
